### PR TITLE
NPM token會改uì Travis設定頁提

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ deploy:
   provider: npm
   skip_cleanup: true
   email: a8568730@gmail.com
-  api_key:
-    secure: o3ZssG7zclWgiv3eXYuFsNklb0saNafhwFCy6INM8h853wQe5yYA9Uo62R8Jrgn9hXKGB2CmYDGGhTrQ3kQBgzvtm9lS3RJRHPyDap9CsoNhY2vIP4WTjq0+ANun/l8JErgS/3fxUKSBWR5Wo7aomWYReVTgak8p2MMeS1Dxvax+3BekC3PJ+v5WCYCiztJ4ciEKLo2Xn3A6ezkmcVXshQ49j8rxiYHghzJpeZ7uYQKYZ1o1C5Kdvhxg98k3wyIxOMGZg+PWTg930kWBJR1Nkw0IuKjS0215VjoM29UbLWRtAU/cz64txn3o6Fa3cMJCG7/DAasrstuiQC3IVodb5ZbS4gAV6H+Q3d/Ylpxa+HTCJa6Dnqi3d10GAyA+DOq0FuadXwxImAm0zRAkUMfqxVwV1ZREKEYMLU6ynLL6awEkhGUY44WMp96B3Fysid8hDEdKNJMqi+iXSav843Ij6iRPbSKOs7ZEAHdYt918qO/mx6mKuysg9rxE6PSQ3FXRPGzVHPYAbDyrdOV4n9uBvzgEIyWOs75w/xx7+x13tNdPHgMZt1qu9rO2sCx7kqPUPmGCqsxRAfBpI0Go94kfaBKRg3gfF1SLzGXrqQoxzUMWOn+dKnmhS0Il52BEZi3hY3HxlohDDWpdE7pFr0RA/UJmAZLpta3rrcypneUEPN4=
+  api_key: ${NPM_TOKEN}
   on:
     tags: true
     repo: i3thuan5/demo-ui


### PR DESCRIPTION
因為欲deprecate，欲申請註銷demo-ui token，所以kā .travis.yml內底npm token提掉。

驚未來會專案koh開開，所以保留deploy指令，token改做uìTravis後台提。

這支kap落去，就會用得kā專案重鎖起來。